### PR TITLE
DEV: Add group-based setting metadata

### DIFF
--- a/javascripts/discourse/services/enforce-edit-reason.js
+++ b/javascripts/discourse/services/enforce-edit-reason.js
@@ -24,6 +24,12 @@ export default class EnforceEditReason extends Service {
   }
 
   get isInGroup() {
+    if (Object.hasOwn(settings, "user_in_edit_reason_required_groups")) {
+      return settings.user_in_edit_reason_required_groups;
+    }
+
+    // TODO (martin) Remove the below fallback code once core has
+    // resolve_group_membership available everywhere.
     const groupSetting = new Set(
       settings.edit_reason_required_groups?.split("|").map(Number)
     );

--- a/settings.yml
+++ b/settings.yml
@@ -2,6 +2,8 @@ edit_reason_required_groups:
   default: ""
   type: list
   list_type: group
+  resolve_group_membership: true
+  disallowed_groups: "0|5"
 
 edit_reason_grace_period:
   default: 0


### PR DESCRIPTION
Since the introduction of `resolve_group_membership` and `disallowed_groups` metadata in [discourse/discourse#41792](https://github.com/discourse/discourse/pull/41792), [discourse/discourse#41756](https://github.com/discourse/discourse/pull/41756), and [discourse/discourse-copy-post#37](https://github.com/discourse/discourse-copy-post/pull/37), we are updating existing theme components to take advantage of these new APIs in an effort to support the removal of the `everyone` pseudogroup from core and increase clarity around group-based settings.

See also https://meta.discourse.org/t/-/402273